### PR TITLE
6507: inline graphviz wasm as base64 in js

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
@@ -77,7 +77,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.min.js</url>
+							<url>https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.js</url>
 							<unpack>false</unpack>
 							<outputDirectory>${download-maven-plugin.output}</outputDirectory>
 						</configuration>


### PR DESCRIPTION
This is required to avoid fetching it as an external resource at runtime.