### PR TITLE
2024-06 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,10 @@
 		<patchId></patchId>
 		<jmc.config.path>${project.basedir}/configuration</jmc.config.path>
 		<!-- Tycho uses Bundle-RequiredExecutionEnvironment key in the MANIFEST file, but setting this here will catch any misconfigured MANIFEST file -->
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<!-- Plugin Versions -->
-		<tycho.version>4.0.4</tycho.version>
+		<tycho.version>4.0.8</tycho.version>
 		<maven.toolchains.version>3.2.0</maven.toolchains.version>
 		<maven.checkstyle.version>3.4.0</maven.checkstyle.version>
 		<!-- Seems like the currently latest spotless version 2.36.0 has some issue with libicu, so going for 2.34.0 now -->
@@ -136,6 +136,7 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<version>${tycho.version}</version>
 						<configuration>
+						    <executionEnvironment>JavaSE-21</executionEnvironment>
 							<target>
 								<artifact>
 									<groupId>org.openjdk.jmc</groupId>
@@ -256,9 +257,9 @@
 					<execution>
 						<id>build-qualifier</id>
 						<phase>validate</phase>
-						<goals>
+						<!--<goals>
 							<goal>build-qualifier</goal>
-						</goals>
+						</goals>-->
 					</execution>
 				</executions>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,6 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<version>${tycho.version}</version>
 						<configuration>
-						    <executionEnvironment>JavaSE-21</executionEnvironment>
 							<target>
 								<artifact>
 									<groupId>org.openjdk.jmc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 	<properties>
 		<!-- Config -->
 		<revision>9.1.0</revision>
-		<changelist>.qualifier</changelist>
+		<changelist>-SNAPSHOT</changelist>
 		<scmConnection>scm:git:git://github.com/openjdk/jmc.git</scmConnection>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -91,10 +91,10 @@
 		<patchId></patchId>
 		<jmc.config.path>${project.basedir}/configuration</jmc.config.path>
 		<!-- Tycho uses Bundle-RequiredExecutionEnvironment key in the MANIFEST file, but setting this here will catch any misconfigured MANIFEST file -->
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<!-- Plugin Versions -->
-		<tycho.version>4.0.8</tycho.version>
+		<tycho.version>4.0.4</tycho.version>
 		<maven.toolchains.version>3.2.0</maven.toolchains.version>
 		<maven.checkstyle.version>3.4.0</maven.checkstyle.version>
 		<!-- Seems like the currently latest spotless version 2.36.0 has some issue with libicu, so going for 2.34.0 now -->
@@ -235,7 +235,7 @@
 				<configuration>
 				<products>
 					<product>
-						<archiveFileName>${groupId}-${project.version}</archiveFileName>
+						<archiveFileName>${project.groupId}-${project.version}</archiveFileName>
 					</product>
 				</products>
 				</configuration>

--- a/releng/platform-definitions/platform-definition-2024-03/platform-definition-2024-03.target
+++ b/releng/platform-definitions/platform-definition-2024-03/platform-definition-2024-03.target
@@ -56,6 +56,7 @@
             <unit id="org.eclipse.jetty.ee9.websocket.servlet" version="12.0.6"/>
             <unit id="org.eclipse.jetty.alpn.client" version="12.0.6"/>
             <unit id="org.eclipse.jetty.websocket.core.client" version="12.0.6"/>
+            <unit id="org.eclipse.jetty.servlet-api" version="5.0.2"/>
             <unit id="jakarta.annotation-api" version="1.3.5"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2024-06/platform-definition-2024-06.target
+++ b/releng/platform-definitions/platform-definition-2024-06/platform-definition-2024-06.target
@@ -56,6 +56,7 @@
             <unit id="org.eclipse.jetty.ee9.websocket.servlet" version="12.0.6"/>
             <unit id="org.eclipse.jetty.alpn.client" version="12.0.6"/>
             <unit id="org.eclipse.jetty.websocket.core.client" version="12.0.6"/>
+            <unit id="org.eclipse.jetty.servlet-api" version="5.0.2"/>
             <unit id="jakarta.annotation-api" version="1.3.5"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
@@ -91,5 +92,5 @@
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
         </location>
     </locations>
-    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2024-06/platform-definition-2024-06.target
+++ b/releng/platform-definitions/platform-definition-2024-06/platform-definition-2024-06.target
@@ -92,5 +92,5 @@
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
         </location>
     </locations>
-    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 </target>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -43,8 +43,8 @@
 	<properties>
 		<!-- Config -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<!-- Plugin Versions -->
 		<p2-maven-plugin.version>2.1.0</p2-maven-plugin.version>
@@ -223,8 +223,8 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>[17,)</version>
-									<message>Building JMC requires Java 17 or later</message>
+									<version>[21,)</version>
+									<message>Building JMC requires Java 21 or later</message>
 								</requireJavaVersion>
 							</rules>
 						</configuration>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -43,8 +43,8 @@
 	<properties>
 		<!-- Config -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<!-- Plugin Versions -->
 		<p2-maven-plugin.version>2.1.0</p2-maven-plugin.version>
@@ -223,8 +223,8 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>[21,)</version>
-									<message>Building JMC requires Java 21 or later</message>
+									<version>[17,)</version>
+									<message>Building JMC requires Java 17 or later</message>
 								</requireJavaVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
Used tycho version 4.0.4 instead of 4.0.8 (Latest).
Maven version to be used 3.9.8. There is no need to upgrade to Java 21. 
@thegreystone : Could you please review the code changes.